### PR TITLE
Edits to clarify known-ULA behavior in relation to the SNAC router RA header flag bit.

### DIFF
--- a/draft-ietf-6man-rfc6724-update.md
+++ b/draft-ietf-6man-rfc6724-update.md
@@ -184,7 +184,7 @@ The following rules define how the learnt known-local ULA prefixes under fd00::/
   
 3. PIOs within fd00::/8 of length /64 that are not already in the nodes known-local ULA list MUST be added to the list with an assumed prefix length of /48, regardless of how the PIO flags are set.
    
-4. ULA interface addresses from within fd00::/8, particularly ones not created by SLAAC, and not already covered by the known-local ULA list MUST be added to the list with an assumed prefix length of /48.
+4. ULA interface addresses from within fd00::/8, particularly ones not created by SLAAC, and not already covered by the known-local ULA list MUST be added to the list with an assumed prefix length of /48. However, as with rule 0, if the ULA interface address was generated on the basis of a PIO that has only been seen in RAs in which the SNAC router flag bit is set MUST NOT be used as described in this rule (rule 4).
 
 5. Regardless of their length or how the PIO flags are set, other PIOs from within fd00::/8 that are not already covered by the known-local ULA list MAY be added to the list, but only with the advertised prefix length.
 


### PR DESCRIPTION
This adds a prerequisite to the list of rules for learning known-local prefixes that if a PIO comes from an RA with the SNAC Router Flag bit set, this PIO MUST be ignored. This avoids the possibility of preferring a ULA source address based on a locally-generated non-routed SNAC "usable prefix" when communicating to a ULA destination.

This also modifies rule 4 to say that if the address being considered was generated as a result of a SNAC PIO, that address should not be considered part of a known-local prefix. This is required because otherwise the first prerequisite usually won't have any effect, since the known-local prefix will just be derived from the SLAAC address from the PIO prefix rather than from the PIO itself.

From an implementation perspective, this means that an implementation needs to remember which prefixes came from PIOs in RAs with the SNAC router bit set, and either needs to remember which addresses were generated with SLAAC based on those prefixes, or else needs to check each interface address to see if it's in a prefix that came from an RA with the SNAC bit set.

I did not document this in the edit, since implementations can achieve the requirements stated in the text however they want, and so I think describing a specific implementation might be confusing. However, we could add such text if the WG thinks it would be helpful.