### PR TITLE
Fix ULA typo (double colons)

### DIFF
--- a/draft-ietf-6man-rfc6724-update.md
+++ b/draft-ietf-6man-rfc6724-update.md
@@ -263,7 +263,7 @@ Host B has address ULA2::1 and GUA1:2::1
 Both ULA prefixes have been determined to be known-local through RIOs.
 Perhaps ULA2 is reachable within the site, but its prefix is not in direct use at host A.
 
-If host A sends to host B the candidate pairs are ULA1::1 - ULA2::1 and GUA1::1::1 - GUA1:2::1.
+If host A sends to host B the candidate pairs are ULA1::1 - ULA2::1 and GUA1:1::1 - GUA1:2::1.
 
 In this case ULA1::1 - ULA2::1 wins because of matching labels (both 14) and higher precedence than GUA (45 vs 40).
 


### PR DESCRIPTION
Fix a typo in ULA address.
Related to https://mailarchive.ietf.org/arch/msg/ipv6/eG5hj5eQWH_0JvG_yX11kxtArRM/